### PR TITLE
* Allow conversion to and from node and web streams

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,5 @@ jspm_packages
 
 # Optional REPL history
 .node_repl_history
+
+package-lock.json

--- a/README.md
+++ b/README.md
@@ -1,35 +1,120 @@
 # @balena/node-web-streams
-WhatWG web streams and conversion utilities for node.js
 
-This is a fork of [gwicke's node-web-streams module](https://github.com/gwicke/node-web-streams),
-which exposes webstream read errors as node error events.
-This is meant to provide a proper npm release until
-[the respective upstream PR](https://github.com/gwicke/node-web-streams/pull/4)
-gets merged.
+WhatWG web streams and conversion utilities for node.js, browser-ready.
 
-This provides the [WhatWG streams](https://streams.spec.whatwg.org) API for
-node. It leverages the [WhatWG reference
-implementation](https://github.com/whatwg/streams), but also addresses
-performance issues in that implementation.
+With the release of the web streams api for node, people are bound to be
+interoperating between the two, which as the motivation for this utility library.
+
+This package is meant to be operable from a node instance or a browser.
+
+If you are going to be working on the browser or an older instance of node
+without the `WebStream API`, you will need the polyfills:
+
+* stream-browserify
+* web-streams-polyfill
+
+Note: This is an experimental api built on top of another experimental api. Use with caution.
+
 
 ## Installation
 ```
 npm install node-web-streams
 ```
 
-## Usage
-```javascript
-// ES5 require syntax
-var webStreams = require('node-web-streams');
-var ReadableStream = webStreams.ReadableStream;
-var toWebReadableStream = webStreams.toWebReadableStream;
-var toNodeReadable = webStreams.toNodeReadable;
+with peer dependencies:
 
-// ES6 import syntax
-import { ReadableStream, toWebReadableStream, toNodeReadable } from "node-web-streams";
-
-// Convert a node Readable to a web ReadableStream & back
-const nodeReadable = require('fs').createReadStream('/tmp/test.txt');
-const webReadable = toWebReadableStream(nodeReadable);
-const roundTrippedNodeReadable = toNodeReadable(webReadable);
 ```
+npm install node-web-streams stream-browserify web-streams-polyfill
+```
+
+## Usage
+
+The `toNode` method converts any underlying stream to a Node stream.
+
+If it's a `ReadableStream`, it will be converted to a `stream.Readable`.
+If it's a `WritableStream`, it will be converted to a `stream.Writable`.
+
+```js
+class MySource {
+  constructor(value = new Uint8Array(10)) {
+    this.value = value;
+  }
+
+  start(c) {
+    this.started = true;
+    this.controller = c;
+  }
+
+  pull(controller) {
+    controller.enqueue(this.value);
+    controller.close();
+  }
+
+  cancel(reason) {
+    this.canceled = true;
+    this.cancelReason = reason;
+  }
+}
+
+const rs = new ReadableStream(MySource);
+
+toNode(rs) // creates a node read stream
+```
+
+It can also take a `ReadableStream` and a `WritableStream` and create a `stream.Duplex`.
+
+```js
+const rs = new ReadableStream(MySource);
+const ws = new WritableStream(MySource);
+
+toNode({readable: rs, writable: ws}, {highWaterMark: 16}) // creates a stream.Duplex
+```
+
+Likewise, streams can be converted to web streams with the `toWeb` methods.
+
+```js
+const sr = Readable.from("hello world")
+toWeb(sr) // creates ReadableStream
+const sw = getStreamWritableSomehow()
+toWeb(sw) // creates WritableStream
+```
+
+And you can create a `ReadableStream` and `WritableStream` from a `stream.Duplex`, like so:
+
+```js
+const duplex = new PassThrough();
+toWeb(duplex) // returns { readable, writable }, a ReadableStream and WritableStream
+```
+
+There is also a pipeline that will convert all streams to node as it pipes them.
+
+```js
+const rs = new ReadableStream(MySource);
+const duplex = new PassThrough();
+const ws = getWritableStreamSomehow();
+pipeline(rs, duplex, ws, err => { // this will convert all streams to node streams
+  if (err) {
+    console.error(err)
+  }
+})
+```
+
+This api will likely change though, so I wouldn't recommend you use it.
+I just have to implement it, but the pipeline will convert the source to the output
+of the last stream in the pipeline.
+
+There are a few other utility functions exported for your convenience if you want to be more explicit:
+
+```
+newStreamDuplexFromReadableWritablePair
+newReadableStreamFromStreamReadable
+newWritableStreamFromStreamWritable
+newStreamWritableFromWritableStream
+newReadableStreamFromStreamReadable
+``
+
+I'll leave it as an exercise to the reader to figure out what they do ;)
+
+### Credits
+
+The code in here was mostly written by @jasnell, I just adapted it to support multiple environments from the node internals.

--- a/index.js
+++ b/index.js
@@ -1,42 +1,27 @@
-'use strict';
-const nodeStream = require('stream');
-const isNodeStream = require('is-stream');
-const conversions = require('./lib/conversions');
+const {
+    newStreamDuplexFromReadableWritablePair,
+    newReadableStreamFromStreamReadable,
+    newWritableStreamFromStreamWritable,
+    newStreamWritableFromWritableStream,
+    newReadableStreamFromStreamReadable,
+} = require('./lib/conversions');
 
-module.exports = require('web-streams-polyfill');
+const {
+    toWeb,
+    toNode,
+} = require('./lib/inferred');
 
-/**
- * Convert Web streams to Node streams. Until WritableStream / TransformStream
- * is finalized, only ReadableStream is supported.
- *
- * @param {ReadableStream} stream, a web stream.
- * @return {stream.Readable}, a Node Readable stream.
- */
-module.exports.toNodeReadable = function(stream) {
-    if (stream instanceof module.exports.ReadableStream
-        || stream && typeof stream.getReader === 'function') {
-        return conversions.readable.webToNode(stream);
-    } else {
-        throw new TypeError("Expected a ReadableStream.");
-    }
-};
+const {
+    pipeline,
+} = require('./lib/pipeline');
 
-/**
- * Convert Node Readable streams, an Array, Buffer or String to a Web
- * ReadableStream.
- *
- * @param {Readable|Array|Buffer|String} stream, a Node Readable stream,
- * Array, Buffer or String.
- * @return {ReadableStream}, a web ReadableStream.
- */
-module.exports.toWebReadableStream = function(stream) {
-    if (isNodeStream(stream) && stream.readable) {
-        return conversions.readable.nodeToWeb(stream);
-    } else if (Array.isArray(stream)) {
-        return conversions.readable.arrayToWeb(stream);
-    } else if (Buffer.isBuffer(stream) || typeof stream === 'string') {
-        return conversions.readable.arrayToWeb([stream]);
-    } else {
-        throw new TypeError("Expected a Node streams.Readable, an Array, Buffer or String.");
-    }
-};
+module.exports = {
+    newStreamDuplexFromReadableWritablePair,
+    newReadableStreamFromStreamReadable,
+    newWritableStreamFromStreamWritable,
+    newStreamWritableFromWritableStream,
+    newReadableStreamFromStreamReadable,
+    toNode,
+    toWeb,
+    pipeline,
+}

--- a/lib/conversions.js
+++ b/lib/conversions.js
@@ -1,96 +1,619 @@
-'use strict';
+const {
+  ReadableStream,
+  WritableStream,
+  Readable,
+  Writable,
+  Duplex,
+  // finished,
+  CountQueuingStrategy,
+} = require('./isomorphic-streams');
+const {
+  finished,
+} = require('stream')
 
-const Readable = require('stream').Readable;
-const ReadableStream = require('web-streams-polyfill').ReadableStream;
+const {
+  createDeferredPromise,
+  isDestroyed,
+  destroy,
+  isWritable,
+  isReadable,
+  isWritableEnded,
+  isReadableEnded,
+  isReadableStream,
+  isWritableStream,
+} = require('./util');
 
-/**
- * Web / node stream conversion functions
- */
+const {
+  validateBoolean,
+  validateObject
+} = require('./validators')
 
-function readableNodeToWeb(nodeStream) {
-    return new ReadableStream({
-        start(controller) {
-            nodeStream.pause();
-            nodeStream.on('data', chunk => {
-                controller.enqueue(chunk);
-                nodeStream.pause();
-            });
-            nodeStream.on('end', () => controller.close());
-            nodeStream.on('error', (e) => controller.error(e));
-        },
-        pull(controller) {
-            nodeStream.resume();
-        },
-        cancel(reason) {
-            nodeStream.pause();
-        }
-    });
-}
+const { AbortError, invalidArgType, invalidArgValue, prematureClose } = require('./errors');
 
-/**
- * ReadableStream wrapping an array.
- *
- * @param {Array} arr, the array to wrap into a stream.
- * @return {ReadableStream}
- */
-function arrayToWeb(arr) {
-    return new ReadableStream({
-        start(controller) {
-            for (var i = 0; i < arr.length; i++) {
-                controller.enqueue(arr[i]);
-            }
-            controller.close();
-        }
-    });
-}
+// const { pthen, pfinally } = Promise.prototype;
 
 
-class NodeReadable extends Readable {
-    constructor(webStream, options) {
-        super(options);
-        this._webStream = webStream;
-        this._reader = webStream.getReader();
-        this._reading = false;
+function newWritableStreamFromStreamWritable(streamWritable) {
+  if (typeof streamWritable?._writableState !== 'object') {
+    throw invalidArgType(
+      'streamWritable',
+      'stream.Writable',
+      streamWritable);
+  }
+
+  if (isDestroyed(streamWritable) || !isWritable(streamWritable)) {
+    const writable = new WritableStream();
+    writable.close();
+    return writable;
+  }
+
+  const highWaterMark = streamWritable.writableHighWaterMark;
+  const strategy =
+    streamWritable.writableObjectMode ?
+      new CountQueuingStrategy({ highWaterMark }) :
+      { highWaterMark };
+
+  let controller;
+  let backpressurePromise;
+  let closed;
+
+  function onDrain() {
+    if (backpressurePromise !== undefined)
+      backpressurePromise.resolve();
+  }
+
+  const cleanup = finished(streamWritable, (error) => {
+    if (error?.code === 'ERR_STREAM_PREMATURE_CLOSE') {
+      const err = new AbortError();
+      err.cause = error;
+      error = err;
     }
 
-    _read(size) {
-        if (this._reading) {
-            return;
-        }
-        this._reading = true;
-        const doRead = () => {
-            this._reader.read()
-                .then(res => {
-                    if (res.done) {
-                        this.push(null);
-                        return;
-                    }
-                    if (this.push(res.value)) {
-                        return doRead(size);
-                    } else {
-                        this._reading = false;
-                    }
-                })
-                .catch(e => this.emit('error', e));
-        };
-        doRead();
+    cleanup();
+    streamWritable.on('error', () => {});
+    if (error != null) {
+      if (backpressurePromise !== undefined)
+        backpressurePromise.reject(error);
+      if (closed !== undefined) {
+        closed.reject(error);
+        closed = undefined;
+      }
+      controller.error(error);
+      controller = undefined;
+      return;
     }
+
+    if (closed !== undefined) {
+      closed.resolve();
+      closed = undefined;
+      return;
+    }
+    controller.error(new AbortError());
+    controller = undefined;
+  });
+
+  streamWritable.on('drain', onDrain);
+
+  return new WritableStream({
+    start(c) { controller = c; },
+
+    async write(chunk) {
+      if (streamWritable.writableNeedDrain || !streamWritable.write(chunk)) {
+        backpressurePromise = createDeferredPromise();
+        return pfinally(
+          backpressurePromise.promise, () => {
+            backpressurePromise = undefined;
+          });
+      }
+    },
+
+    abort(reason) {
+      destroy(streamWritable, reason);
+    },
+
+    close() {
+      if (closed === undefined && !isWritableEnded(streamWritable)) {
+        closed = createDeferredPromise();
+        streamWritable.end();
+        return closed.promise;
+      }
+
+      controller = undefined;
+      return PromiseResolve();
+    },
+  }, strategy);
 }
 
-function readableWebToNode(webStream) {
-    return new NodeReadable(webStream);
+function newStreamWritableFromWritableStream(writableStream, options = {}) {
+  if (!isWritableStream(writableStream)) {
+    throw invalidArgType(
+      'writableStream',
+      'WritableStream',
+      writableStream);
+  }
+
+  validateObject(options, 'options');
+  const {
+    highWaterMark,
+    decodeStrings = true,
+    objectMode = false,
+    signal,
+  } = options;
+
+  validateBoolean(objectMode, 'options.objectMode');
+  validateBoolean(decodeStrings, 'options.decodeStrings');
+
+  const writer = writableStream.getWriter();
+  let closed = false;
+
+  const writable = new Writable({
+    highWaterMark,
+    objectMode,
+    decodeStrings,
+    signal,
+
+    writev(chunks, callback) {
+      function done(error) {
+        try {
+          callback(error);
+        } catch (error) {
+          setImmediate(() => destroy(writable, error));
+        }
+      }
+
+      writer.ready.then(
+        () => {
+          return Promise.all(chunks.map((chunk) => writer.write(chunk))).then(
+            done,
+            done);
+        },
+        done);
+    },
+
+    write(chunk, encoding, callback) {
+      if (typeof chunk === 'string' && decodeStrings && !objectMode) {
+        chunk = Buffer.from(chunk, encoding);
+        chunk = new Uint8Array(
+          chunk.buffer,
+          chunk.byteOffset,
+          chunk.byteLength);
+      }
+
+      function done(error) {
+        try {
+          callback(error);
+        } catch (error) {
+          destroy(writable, error);
+        }
+      }
+
+        writer.ready.then(() => {
+          return writer.write(chunk).then(done, done);
+        },
+        done);
+    },
+
+    destroy(error, callback) {
+      function done() {
+        try {
+          callback(error);
+        } catch (error) {
+          setImmediate(() => { throw error; });
+        }
+      }
+
+      if (!closed) {
+        if (error != null) {
+            writer.abort(error).then(
+            done,
+            done);
+        } else {
+            writer.close().then(
+            done,
+            done);
+        }
+        return;
+      }
+
+      done();
+    },
+
+    final(callback) {
+      function done(error) {
+        try {
+          callback(error);
+        } catch (error) {
+          setImmediate(() => destroy(writable, error));
+        }
+      }
+
+      if (!closed) {
+          writer.close().then(
+          done,
+          done);
+      }
+    },
+  });
+
+    writer.closed.then(
+    () => {
+      closed = true;
+      if (!isWritableEnded(writable))
+        destroy(writable, prematureClose());
+    },
+    (error) => {
+      closed = true;
+      destroy(writable, error);
+    });
+
+  return writable;
 }
+
+function newReadableStreamFromStreamReadable(streamReadable) {
+  if (typeof streamReadable?._readableState !== 'object') {
+    throw invalidArgType(
+      'streamReadable',
+      'stream.Readable',
+      streamReadable);
+  }
+
+  if (isDestroyed(streamReadable) || !isReadable(streamReadable)) {
+    const readable = new ReadableStream();
+    readable.cancel();
+    return readable;
+  }
+
+  const objectMode = streamReadable.readableObjectMode;
+  const highWaterMark = streamReadable.readableHighWaterMark;
+  const strategy =
+    objectMode ?
+      new CountQueuingStrategy({ highWaterMark }) :
+      { highWaterMark };
+
+  let controller;
+
+  function onData(chunk) {
+    // Copy the Buffer to detach it from the pool.
+    if (Buffer.isBuffer(chunk) && !objectMode)
+      chunk = new Uint8Array(chunk);
+    controller.enqueue(chunk);
+    if (controller.desiredSize <= 0)
+      streamReadable.pause();
+  }
+
+  streamReadable.pause();
+
+  const cleanup = finished(streamReadable, (error) => {
+    if (error?.code === 'ERR_STREAM_PREMATURE_CLOSE') {
+      const err = new AbortError();
+      err.cause = error;
+      error = err;
+    }
+
+    cleanup();
+    streamReadable.on('error', () => {});
+    if (error)
+      return controller.error(error);
+    controller.close();
+  });
+
+  streamReadable.on('data', onData);
+
+  return new ReadableStream({
+    start(c) { controller = c; },
+
+    pull() { streamReadable.resume(); },
+
+    cancel(reason) {
+      destroy(streamReadable, reason);
+    },
+  }, strategy);
+}
+
+function newStreamReadableFromReadableStream(readableStream, options = {}) {
+  if (!isReadableStream(readableStream)) {
+    throw invalidArgType(
+      'readableStream',
+      'ReadableStream',
+      readableStream);
+  }
+
+  validateObject(options, 'options');
+  const {
+    highWaterMark,
+    encoding,
+    objectMode = false,
+    signal,
+  } = options;
+
+  if (encoding !== undefined && !Buffer.isEncoding(encoding))
+    throw invalidArgValue(encoding, 'options.encoding');
+  validateBoolean(objectMode, 'options.objectMode');
+
+  const reader = readableStream.getReader();
+  let closed = false;
+
+  const readable = new Readable({
+    objectMode,
+    highWaterMark,
+    encoding,
+    signal,
+
+    read() {
+        reader.read().then(
+        (chunk) => {
+          if (chunk.done) {
+            // Value should always be undefined here.
+            readable.push(null);
+          } else {
+            readable.push(chunk.value);
+          }
+        },
+        (error) => destroy(readable, error));
+    },
+
+    destroy(error, callback) {
+      function done() {
+        try {
+          callback(error);
+        } catch (error) {
+          setImmediate(() => { throw error; });
+        }
+      }
+
+      if (!closed) {
+          reader.cancel(error).then(
+          done,
+          done);
+        return;
+      }
+      done();
+    },
+  });
+
+    reader.closed.then(
+    () => {
+      closed = true;
+      if (!isReadableEnded(readable))
+        readable.push(null);
+    },
+    (error) => {
+      closed = true;
+      destroy(readable, error);
+    });
+
+  return readable;
+}
+
+function newReadableWritablePairFromDuplex(duplex) {
+  if (typeof duplex?._writableState !== 'object' ||
+      typeof duplex?._readableState !== 'object') {
+    throw invalidArgType('duplex', 'stream.Duplex', duplex);
+  }
+
+  if (isDestroyed(duplex)) {
+    const writable = new WritableStream();
+    const readable = new ReadableStream();
+    writable.close();
+    readable.cancel();
+    return { readable, writable };
+  }
+
+  const writable =
+    isWritable(duplex) ?
+      newWritableStreamFromStreamWritable(duplex) :
+      new WritableStream();
+
+  if (!isWritable(duplex))
+    writable.close();
+
+  const readable =
+    isReadable(duplex) ?
+      newReadableStreamFromStreamReadable(duplex) :
+      new ReadableStream();
+
+  if (!isReadable(duplex))
+    readable.cancel();
+
+  return { writable, readable };
+}
+
+function newStreamDuplexFromReadableWritablePair(pair = {}, options = {}) {
+  validateObject(pair, 'pair');
+  const {
+    readable: readableStream,
+    writable: writableStream,
+  } = pair;
+
+  if (!isReadableStream(readableStream)) {
+    throw invalidArgType(
+      'pair.readable',
+      'ReadableStream',
+      readableStream);
+  }
+  if (!isWritableStream(writableStream)) {
+    throw invalidArgType(
+      'pair.writable',
+      'WritableStream',
+      writableStream);
+  }
+
+  validateObject(options, 'options');
+  const {
+    allowHalfOpen = false,
+    objectMode = false,
+    encoding,
+    decodeStrings = true,
+    highWaterMark,
+    signal,
+  } = options;
+
+  validateBoolean(objectMode, 'options.objectMode');
+  if (encoding !== undefined && !Buffer.isEncoding(encoding))
+    throw invalidArgValue(encoding, 'options.encoding');
+
+  const writer = writableStream.getWriter();
+  const reader = readableStream.getReader();
+  let writableClosed = false;
+  let readableClosed = false;
+
+  const duplex = new Duplex({
+    allowHalfOpen,
+    highWaterMark,
+    objectMode,
+    encoding,
+    decodeStrings,
+    signal,
+
+    writev(chunks, callback) {
+      function done(error) {
+        try {
+          callback(error);
+        } catch (error) {
+          // In a next tick because this is happening within
+          // a promise context, and if there are any errors
+          // thrown we don't want those to cause an unhandled
+          // rejection. Let's just escape the promise and
+          // handle it separately.
+          setImmediate(() => destroy(duplex, error));
+        }
+      }
+
+        writer.ready.then(
+        () => {
+            Promise.all(
+                chunks.map((chunk) => writer.write(chunk))).then(
+            done,
+            done);
+        },
+        done);
+    },
+
+    write(chunk, encoding, callback) {
+      if (typeof chunk === 'string' && decodeStrings && !objectMode) {
+        chunk = Buffer.from(chunk, encoding);
+        chunk = new Uint8Array(
+          chunk.buffer,
+          chunk.byteOffset,
+          chunk.byteLength);
+      }
+
+      function done(error) {
+        try {
+          callback(error);
+        } catch (error) {
+          destroy(duplex, error);
+        }
+      }
+
+        writer.ready.then(
+        () => {
+            writer.write(chunk).then(
+            done,
+            done);
+        },
+        done);
+    },
+
+    final(callback) {
+      function done(error) {
+        try {
+          callback(error);
+        } catch (error) {
+          setImmediate(() => destroy(duplex, error));
+        }
+      }
+
+      if (!writableClosed) {
+          writer.close().then(
+          done,
+          done);
+      }
+    },
+
+    read() {
+        reader.read().then(
+        (chunk) => {
+          if (chunk.done) {
+            duplex.push(null);
+          } else {
+            duplex.push(chunk.value);
+          }
+        },
+        (error) => destroy(duplex, error));
+    },
+
+    destroy(error, callback) {
+      function done() {
+        try {
+          callback(error);
+        } catch (error) {
+          // In a next tick because this is happening within
+          // a promise context, and if there are any errors
+          // thrown we don't want those to cause an unhandled
+          // rejection. Let's just escape the promise and
+          // handle it separately.
+          setImmediate(() => { throw error; });
+        }
+      }
+
+      async function closeWriter() {
+        if (!writableClosed)
+          await writer.abort(error);
+      }
+
+      async function closeReader() {
+        if (!readableClosed)
+          await reader.cancel(error);
+      }
+
+      if (!writableClosed || !readableClosed) {
+          Promise.all([
+            closeWriter(),
+            closeReader(),
+          ]).then(
+          done,
+          done);
+        return;
+      }
+
+      done();
+    },
+  });
+
+    writer.closed.then(
+    () => {
+      writableClosed = true;
+      if (!isWritableEnded(duplex))
+        destroy(duplex, new ERR_STREAM_PREMATURE_CLOSE());
+    },
+    (error) => {
+      writableClosed = true;
+      readableClosed = true;
+      destroy(duplex, error);
+    });
+
+    reader.closed.then(
+    () => {
+      readableClosed = true;
+      if (!isReadableEnded(duplex))
+        duplex.push(null);
+    },
+    (error) => {
+      writableClosed = true;
+      readableClosed = true;
+      destroy(duplex, error);
+    });
+
+  return duplex;
+}
+
 
 module.exports = {
-    readable: {
-        nodeToWeb: readableNodeToWeb,
-        arrayToWeb: arrayToWeb,
-        webToNode: readableWebToNode,
-    },
+  newWritableStreamFromStreamWritable,
+  newReadableStreamFromStreamReadable,
+  newStreamWritableFromWritableStream,
+  newStreamReadableFromReadableStream,
+  newReadableWritablePairFromDuplex,
+  newStreamDuplexFromReadableWritablePair,
 };
-
-// Simple round-trip test.
-// let nodeReader = require('fs').createReadStream('/tmp/test.txt');
-// let webReader = readableNodeToWeb(nodeReader);
-// let roundTrippedReader = readableWebToNode(webReader);
-// roundTrippedReader.pipe(process.stdout);

--- a/lib/end-of-stream.js
+++ b/lib/end-of-stream.js
@@ -1,0 +1,216 @@
+// Ported from https://github.com/mafintosh/end-of-stream with
+// permission from the author, Mathias Buus (@mafintosh).
+
+'use strict';
+
+const {
+  AbortError,
+  prematureClose,
+} = require('./errors');
+const {
+  validateAbortSignal,
+  validateFunction,
+  validateObject,
+} = require('./validators');
+
+const {
+  isClosed,
+  isReadable,
+  isReadableNodeStream,
+  isReadableFinished,
+  isWritable,
+  isWritableNodeStream,
+  isWritableFinished,
+  isNodeStream,
+  willEmitClose: _willEmitClose,
+  isIterable,
+  once,
+} = require('./util');
+
+function isRequest(stream) {
+  return stream.setHeader && typeof stream.abort === 'function';
+}
+
+const nop = () => {};
+
+function eos(stream, options, callback) {
+  if (arguments.length === 2) {
+    callback = options;
+    options = {};
+  } else if (options == null) {
+    options = {};
+  } else {
+    validateObject(options, 'options');
+  }
+  validateFunction(callback, 'callback');
+  validateAbortSignal(options.signal, 'options.signal');
+
+  callback = once(callback);
+
+  const readable = options.readable ||
+    (options.readable !== false && isReadableNodeStream(stream));
+  const writable = options.writable ||
+    (options.writable !== false && isWritableNodeStream(stream));
+
+  if (isNodeStream(stream)) {
+    // Do nothing...
+  } else {
+    // TODO: Webstreams.
+    // TODO: Throw INVALID_ARG_TYPE.
+  }
+
+  const wState = stream._writableState;
+  const rState = stream._readableState;
+
+  const onlegacyfinish = () => {
+    if (!stream.writable) onfinish();
+  };
+
+  // TODO (ronag): Improve soft detection to include core modules and
+  // common ecosystem modules that do properly emit 'close' but fail
+  // this generic check.
+  let willEmitClose = (
+    _willEmitClose(stream) &&
+    isReadableNodeStream(stream) === readable &&
+    isWritableNodeStream(stream) === writable
+  );
+
+  let writableFinished = isWritableFinished(stream, false);
+  const onfinish = () => {
+    writableFinished = true;
+    // Stream should not be destroyed here. If it is that
+    // means that user space is doing something differently and
+    // we cannot trust willEmitClose.
+    if (stream.destroyed) willEmitClose = false;
+
+    if (willEmitClose && (!stream.readable || readable)) return;
+    if (!readable || readableFinished) callback.call(stream);
+  };
+
+  let readableFinished = isReadableFinished(stream, false);
+  const onend = () => {
+    readableFinished = true;
+    // Stream should not be destroyed here. If it is that
+    // means that user space is doing something differently and
+    // we cannot trust willEmitClose.
+    if (stream.destroyed) willEmitClose = false;
+
+    if (willEmitClose && (!stream.writable || writable)) return;
+    if (!writable || writableFinished) callback.call(stream);
+  };
+
+  const onerror = (err) => {
+    callback.call(stream, err);
+  };
+
+  let closed = isClosed(stream);
+
+  const onclose = () => {
+    closed = true;
+
+    const errored = wState?.errored || rState?.errored;
+
+    if (errored && typeof errored !== 'boolean') {
+      return callback.call(stream, errored);
+    }
+
+    if (readable && !readableFinished) {
+      if (!isReadableFinished(stream, false))
+        return callback.call(stream,
+                             prematureClose());
+    }
+    if (writable && !writableFinished) {
+      if (!isWritableFinished(stream, false))
+        return callback.call(stream,
+                             prematureClose());
+    }
+
+    callback.call(stream);
+  };
+
+  const onrequest = () => {
+    stream.req.on('finish', onfinish);
+  };
+
+  if (isRequest(stream)) {
+    stream.on('complete', onfinish);
+    if (!willEmitClose) {
+      stream.on('abort', onclose);
+    }
+    if (stream.req) onrequest();
+    else stream.on('request', onrequest);
+  } else if (writable && !wState) { // legacy streams
+    stream.on('end', onlegacyfinish);
+    stream.on('close', onlegacyfinish);
+  }
+
+  // Not all streams will emit 'close' after 'aborted'.
+  if (!willEmitClose && typeof stream.aborted === 'boolean') {
+    stream.on('aborted', onclose);
+  }
+
+  stream.on('end', onend);
+  stream.on('finish', onfinish);
+  if (options.error !== false) stream.on('error', onerror);
+  stream.on('close', onclose);
+
+  if (closed) {
+    setImmediate(onclose);
+  } else if (wState?.errorEmitted || rState?.errorEmitted) {
+    if (!willEmitClose) {
+      setImmediate(onclose);
+    }
+  } else if (
+    !readable &&
+    (!willEmitClose || isReadable(stream)) &&
+    (writableFinished || !isWritable(stream))
+  ) {
+    setImmediate(onclose);
+  } else if (
+    !writable &&
+    (!willEmitClose || isWritable(stream)) &&
+    (readableFinished || !isReadable(stream))
+  ) {
+    setImmediate(onclose);
+  } else if ((rState && stream.req && stream.aborted)) {
+    setImmediate(onclose);
+  }
+
+  const cleanup = () => {
+    callback = nop;
+    stream.removeListener('aborted', onclose);
+    stream.removeListener('complete', onfinish);
+    stream.removeListener('abort', onclose);
+    stream.removeListener('request', onrequest);
+    if (stream.req) stream.req.removeListener('finish', onfinish);
+    stream.removeListener('end', onlegacyfinish);
+    stream.removeListener('close', onlegacyfinish);
+    stream.removeListener('finish', onfinish);
+    stream.removeListener('end', onend);
+    stream.removeListener('error', onerror);
+    stream.removeListener('close', onclose);
+  };
+
+  if (options.signal && !closed) {
+    const abort = () => {
+      // Keep it because cleanup removes it.
+      const endCallback = callback;
+      cleanup();
+      endCallback.call(stream, new AbortError());
+    };
+    if (options.signal.aborted) {
+      setImmediate(abort);
+    } else {
+      const originalCallback = callback;
+      callback = once((...args) => {
+        options.signal.removeEventListener('abort', abort);
+        originalCallback.apply(stream, args);
+      });
+      options.signal.addEventListener('abort', abort);
+    }
+  }
+
+  return cleanup;
+}
+
+module.exports = eos;

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -1,0 +1,62 @@
+const ERR_INVALID_ARG_TYPE = 'ERR_INVALID_ARG_TYPE';
+const ERR_INVALID_ARG_VALUE = 'ERR_INVALID_ARG_VALUE';
+const ERR_STREAM_PREMATURE_CLOSE = 'ERR_STREAM_PREMATURE_CLOSE';
+const ERR_INVALID_RETURN_VALUE = 'ERR_INVALID_RETURN_VALUE';
+const ERR_MISSING_ARGS = 'ERR_MISSING_ARGS';
+const ERR_STREAM_DESTROYED = 'ERR_STREAM_DESTROYED';
+
+
+const invalidArgType = (name, expected, actual) => {
+  const err = new Error("Expected: " + expected + " for " + name + ", got: " + actual);
+  err.code = ERR_INVALID_ARG_TYPE;
+  return err;
+}
+
+const invalidArgValue = (invalid, name) => {
+  const err = new Error("Invalid argument: " + invalid + " for " + name );
+  err.code = ERR_INVALID_ARG_VALUE;
+  return err;
+}
+
+const invalidReturnValue = (name, input, value) => {
+  const err = new Error("Invalid return value for " + name + " when received " + input + " returned " + value );
+  err.code = ERR_INVALID_RETURN_VALUE;
+  return err;
+}
+
+const streamDestroyed = (name) => {
+  const err = new Error("Cannot call " + name + " after stream destroyed.");
+  err.code = ERR_STREAM_DESTROYED;
+  return err;
+}
+
+const missingArgs = (...args) => {
+  const err = new Error("Missing args " + args.join("&&"));
+  err.code = ERR_MISSING_ARGS;
+  return err;
+}
+
+const prematureClose = () => {
+  const err = new Error("stream closed prematurely.");
+  err.code = ERR_STREAM_PREMATURE_CLOSE;
+  return err;
+
+}
+
+class AbortError extends Error {
+  constructor() {
+    super('The operation was aborted');
+    this.code = 'ABORT_ERR';
+    this.name = 'AbortError';
+  }
+}
+
+module.exports = {
+  AbortError,
+  prematureClose,
+  missingArgs,
+  streamDestroyed,
+  invalidArgType,
+  invalidArgValue,
+  invalidReturnValue,
+}

--- a/lib/inferred.js
+++ b/lib/inferred.js
@@ -1,0 +1,49 @@
+const { newReadableStreamFromStreamReadable, newWritableStreamFromStreamWritable, newReadableWritablePairFromDuplex, newStreamDuplexFromReadableWritablePair, newStreamWritableFromWritableStream, newStreamReadableFromReadableStream } = require('./conversions');
+const {
+  isReadableStream,
+  isWritableStream,
+  isTransformStream,
+  isDuplexNodeStream,
+  isReadableNodeStream,
+  isWritableNodeStream,
+} = require('./util');
+
+const toWeb = (stream) => {
+  if (isReadableStream(stream) || isWritableStream(stream) || isTransformStream(stream)) {
+    return stream;
+  }
+  if (isDuplexNodeStream(stream)) {
+      return newReadableWritablePairFromDuplex(stream, stream2)
+  }
+  if (isReadableNodeStream(stream)) {
+    return newReadableStreamFromStreamReadable(stream);
+  }
+  if (isWritableNodeStream(stream)) {
+      return newWritableStreamFromStreamWritable(stream);
+  }
+  throw new Error('argument must be a stream stream.')
+}
+
+const toNode = (stream, options) => {
+    if (isReadableNodeStream(stream) || isWritableNodeStream(stream) || isDuplexNodeStream(stream)) {
+        return stream;
+    }
+    if (typeof stream === "object" && (stream.writable && stream.readable)) {
+        return newStreamDuplexFromReadableWritablePair(stream, options)
+    }
+    if (isTransformStream(stream)) {
+        throw new Error("Not yet implemented");
+    }
+    if (isReadableStream(stream)) {
+        return newStreamReadableFromReadableStream(stream);
+    }
+    if (isWritableStream(stream)) {
+        return newStreamWritableFromWritableStream(stream);
+    }
+    throw new Error("Unrecognized arguments, " + stream + options + " must be a stream")
+}
+
+module.exports = {
+  toWeb,
+  toNode,
+}

--- a/lib/isomorphic-streams/browser.js
+++ b/lib/isomorphic-streams/browser.js
@@ -1,0 +1,6 @@
+const browserWebStreams = typeof ReadableStream === "undefined" ? require('web-streams-polyfill') : window
+
+module.exports = {
+  ...require('stream-browserify'),
+  ...browserWebStreams,
+}

--- a/lib/isomorphic-streams/node.js
+++ b/lib/isomorphic-streams/node.js
@@ -1,0 +1,13 @@
+const exists = path => {
+  try {
+    require.resolve(path)
+    return true
+  } catch (err) {
+    return false
+  }
+}
+
+module.exports = {
+  ...require('stream'),
+  ...(!exists('stream/web') ? require('web-streams-polyfill') : require('stream/web'))
+}

--- a/lib/isomorphic-streams/package.json
+++ b/lib/isomorphic-streams/package.json
@@ -1,0 +1,4 @@
+{
+  "main": "./node.js",
+  "browser": "./browser.js"
+}

--- a/lib/pipeline.js
+++ b/lib/pipeline.js
@@ -1,0 +1,304 @@
+
+const eos = require('./end-of-stream');
+const { destroy } = require('./util');
+const { Duplex } = require('./isomorphic-streams');
+
+const {
+  aggregateTwoErrors,
+  invalidReturnValue,
+  missingArgs,
+  streamDestroyed,
+  AbortError,
+} = require('./errors');
+
+const {
+  validateCallback,
+  validateAbortSignal
+} = require('./validators');
+
+const {
+  isIterable,
+  isReadableNodeStream,
+  isNodeStream,
+  once,
+} = require('./util');
+const { toNode } = require('./inferred');
+
+let PassThrough;
+
+
+function destroyer(stream, reading, writing, callback) {
+  callback = once(callback);
+
+  let finished = false;
+  stream.on('close', () => {
+    finished = true;
+  });
+
+  eos(stream, { readable: reading, writable: writing }, (err) => {
+    finished = !err;
+
+    const rState = stream._readableState;
+    if (
+      err &&
+      err.code === 'ERR_STREAM_PREMATURE_CLOSE' &&
+      reading &&
+      (rState && rState.ended && !rState.errored && !rState.errorEmitted)
+    ) {
+      // Some readable streams will emit 'close' before 'end'. However, since
+      // this is on the readable side 'end' should still be emitted if the
+      // stream has been ended and no error emitted. This should be allowed in
+      // favor of backwards compatibility. Since the stream is piped to a
+      // destination this should not result in any observable difference.
+      // We don't need to check if this is a writable premature close since
+      // eos will only fail with premature close on the reading side for
+      // duplex streams.
+      stream
+        .once('end', callback)
+        .once('error', callback);
+    } else {
+      callback(err);
+    }
+  });
+
+  return (err) => {
+    if (finished) return;
+    finished = true;
+    destroy(stream, err);
+    callback(err || streamDestroyed('pipe'));
+  };
+}
+
+function popCallback(streams) {
+  // Streams should never be an empty array. It should always contain at least
+  // a single stream. Therefore optimize for the average case instead of
+  // checking for length === 0 as well.
+  validateCallback(streams[streams.length - 1]);
+  return streams.pop();
+}
+
+function makeAsyncIterable(val) {
+  if (isIterable(val)) {
+    return val;
+  }
+  throw invalidArgType(
+    'val', ['Readable', 'Iterable', 'AsyncIterable'], val);
+}
+
+async function pump(iterable, writable, finish) {
+  let error;
+  let onresolve = null;
+
+  const resume = (err) => {
+    if (err) {
+      error = err;
+    }
+
+    if (onresolve) {
+      const callback = onresolve;
+      onresolve = null;
+      callback();
+    }
+  };
+
+  const wait = () => new Promise((resolve, reject) => {
+    if (error) {
+      reject(error);
+    } else {
+      onresolve = () => {
+        if (error) {
+          reject(error);
+        } else {
+          resolve();
+        }
+      };
+    }
+  });
+
+  writable.on('drain', resume);
+  const cleanup = eos(writable, { readable: false }, resume);
+
+  try {
+    if (writable.writableNeedDrain) {
+      await wait();
+    }
+
+    for await (const chunk of iterable) {
+      if (!writable.write(chunk)) {
+        await wait();
+      }
+    }
+
+    writable.end();
+
+    await wait();
+
+    finish();
+  } catch (err) {
+    finish(error !== err ? aggregateTwoErrors(error, err) : err);
+  } finally {
+    cleanup();
+    writable.off('drain', resume);
+  }
+}
+
+function pipeline(...streams) {
+  const callback = once(popCallback(streams));
+
+  // stream.pipeline(streams, callback)
+  if (Array.isArray(streams[0]) && streams.length === 1) {
+    streams = streams[0];
+  }
+
+  return pipelineImpl(streams, callback);
+}
+
+function pipelineImpl(streams, callback, opts) {
+  if (streams.length < 2) {
+    throw missingArgs('streams');
+  }
+
+  const ac = new AbortController();
+  const signal = ac.signal;
+  const outerSignal = opts?.signal;
+
+  validateAbortSignal(outerSignal, 'options.signal');
+
+  function abort() {
+    finishImpl(new AbortError());
+  }
+
+  outerSignal?.addEventListener('abort', abort);
+
+  let error;
+  let value;
+  const destroys = [];
+
+  let finishCount = 0;
+
+  function finish(err) {
+    finishImpl(err, --finishCount === 0);
+  }
+
+  function finishImpl(err, final) {
+    if (err && (!error || error.code === 'ERR_STREAM_PREMATURE_CLOSE')) {
+      error = err;
+    }
+
+    if (!error && !final) {
+      return;
+    }
+
+    while (destroys.length) {
+      destroys.shift()(error);
+    }
+
+    outerSignal?.removeEventListener('abort', abort);
+    ac.abort();
+
+    if (final) {
+      callback(error, value);
+    }
+  }
+
+  let ret;
+  for (let i = 0; i < streams.length; i++) {
+    const stream = toNode(streams[i]);
+    const reading = i < streams.length - 1;
+    const writing = i > 0;
+
+    if (isNodeStream(stream)) {
+      finishCount++;
+      destroys.push(destroyer(stream, reading, writing, finish));
+    }
+
+    if (i === 0) {
+      if (typeof stream === 'function') {
+        ret = stream({ signal });
+        if (!isIterable(ret)) {
+          throw invalidReturnValue(
+            'Iterable, AsyncIterable or Stream', 'source', ret);
+        }
+      } else if (isIterable(stream) || isReadableNodeStream(stream)) {
+        ret = stream;
+      } else {
+        ret = Duplex.from(stream);
+      }
+    } else if (typeof stream === 'function') {
+      ret = makeAsyncIterable(ret);
+      ret = stream(ret, { signal });
+
+      if (reading) {
+        if (!isIterable(ret, true)) {
+          throw invalidReturnValue(
+            'AsyncIterable', `transform[${i - 1}]`, ret);
+        }
+      } else {
+        if (!PassThrough) {
+          PassThrough = require('./lib/isomorphic-streams');
+        }
+
+        // If the last argument to pipeline is not a stream
+        // we must create a proxy stream so that pipeline(...)
+        // always returns a stream which can be further
+        // composed through `.pipe(stream)`.
+
+        const pt = new PassThrough({
+          objectMode: true
+        });
+
+        // Handle Promises/A+ spec, `then` could be a getter that throws on
+        // second use.
+        const then = ret?.then;
+        if (typeof then === 'function') {
+          then.call(ret,
+                    (val) => {
+                      value = val;
+                      pt.end(val);
+                    }, (err) => {
+                      pt.destroy(err);
+                    },
+          );
+        } else if (isIterable(ret, true)) {
+          finishCount++;
+          pump(ret, pt, finish);
+        } else {
+          throw invalidReturnValue(
+            'AsyncIterable or Promise', 'destination', ret);
+        }
+
+        ret = pt;
+
+        finishCount++;
+        destroys.push(destroyer(ret, false, true, finish));
+      }
+    } else if (isNodeStream(stream)) {
+      if (isReadableNodeStream(ret)) {
+        ret.pipe(stream);
+
+        // Compat. Before node v10.12.0 stdio used to throw an error so
+        // pipe() did/does not end() stdio destinations.
+        // Now they allow it but "secretly" don't close the underlying fd.
+        if (stream === process.stdout || stream === process.stderr) {
+          ret.on('end', () => stream.end());
+        }
+      } else {
+        ret = makeAsyncIterable(ret);
+
+        finishCount++;
+        pump(ret, stream, finish);
+      }
+      ret = stream;
+    } else {
+      ret = Duplex.from(stream);
+    }
+  }
+
+  if (signal?.aborted || outerSignal?.aborted) {
+    setImmediate(abort);
+  }
+
+  return ret;
+}
+
+module.exports = { pipelineImpl, pipeline };

--- a/lib/util.js
+++ b/lib/util.js
@@ -1,0 +1,237 @@
+const {
+  ReadableStream,
+  WritableStream,
+  TransformStream,
+} = require('./isomorphic-streams');
+const createDeferredPromise = () => {
+  let resolve;
+  let reject;
+  const promise = new Promise((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+
+  return { promise, resolve, reject };
+}
+const { AbortError } = require('./errors')
+
+const isReadableStream = thing => thing instanceof ReadableStream;
+const isWritableStream = thing => thing instanceof WritableStream;
+const isTransformStream = thing => thing instanceof TransformStream;
+
+function isDestroyed(stream) {
+  if (!isNodeStream(stream)) return null;
+  const wState = stream._writableState;
+  const rState = stream._readableState;
+  const state = wState || rState;
+  return !!(stream.destroyed || state?.destroyed);
+}
+
+function isReadableNodeStream(obj) {
+  return !!(
+    obj &&
+    typeof obj.pipe === 'function' &&
+    typeof obj.on === 'function' &&
+    (!obj._writableState || obj._readableState?.readable !== false) && // Duplex
+    (!obj._writableState || obj._readableState) // Writable has .pipe.
+  );
+}
+
+function isWritableNodeStream(obj) {
+  return !!(
+    obj &&
+    typeof obj.write === 'function' &&
+    typeof obj.on === 'function' &&
+    (!obj._readableState || obj._writableState?.writable !== false) // Duplex
+  );
+}
+
+function isDuplexNodeStream(obj) {
+  return !!(
+    obj &&
+    (typeof obj.pipe === 'function' && obj._readableState) &&
+    typeof obj.on === 'function' &&
+    typeof obj.write === 'function'
+  );
+}
+
+function isNodeStream(obj) {
+  return (
+    obj &&
+    (
+      obj._readableState ||
+      obj._writableState ||
+      (typeof obj.write === 'function' && typeof obj.on === 'function') ||
+      (typeof obj.pipe === 'function' && typeof obj.on === 'function')
+    )
+  );
+}
+
+const destroy = (stream, err) => {
+  if (!stream || isDestroyed(stream)) {
+    return;
+  }
+
+  if (!err && !isFinished(stream)) {
+    err = new AbortError();
+  }
+  if (typeof stream.abort === "function") {
+    stream.abort();
+  } else if (typeof stream.destroy === "function") {
+    stream.destroy(err);
+  } else if (typeof stream.close === "function") {
+    stream.close();
+  }
+}
+
+function isReadable(stream) {
+  const r = isReadableNodeStream(stream);
+  if (r === null || typeof stream?.readable !== 'boolean') return null;
+  if (isDestroyed(stream)) return false;
+  return r && stream.readable && !isReadableFinished(stream);
+}
+
+function isWritable(stream) {
+  const r = isWritableNodeStream(stream);
+  if (r === null || typeof stream?.writable !== 'boolean') return null;
+  if (isDestroyed(stream)) return false;
+  return r && stream.writable && !isWritableEnded(stream);
+}
+
+function isFinished(stream, opts) {
+  if (!isNodeStream(stream)) {
+    return null;
+  }
+
+  if (isDestroyed(stream)) {
+    return true;
+  }
+
+  if (opts?.readable !== false && isReadable(stream)) {
+    return false;
+  }
+
+  if (opts?.writable !== false && isWritable(stream)) {
+    return false;
+  }
+
+  return true;
+}
+
+function isWritableEnded(stream) {
+  if (!isWritableNodeStream(stream)) return null;
+  if (stream.writableEnded === true) return true;
+  const wState = stream._writableState;
+  if (wState?.errored) return false;
+  if (typeof wState?.ended !== 'boolean') return null;
+  return wState.ended;
+}
+
+function isReadableEnded(stream) {
+  if (!isReadableNodeStream(stream)) return null;
+  if (stream.readableEnded === true) return true;
+  const rState = stream._readableState;
+  if (!rState || rState.errored) return false;
+  if (typeof rState?.ended !== 'boolean') return null;
+  return rState.ended;
+}
+
+function once(callback) {
+  let called = false;
+  return function(...args) {
+    if (called) return;
+    called = true;
+    Reflect.apply(callback, this, args);
+  };
+}
+
+function isWritableFinished(stream, strict) {
+  if (!isWritableNodeStream(stream)) return null;
+  if (stream.writableFinished === true) return true;
+  const wState = stream._writableState;
+  if (wState?.errored) return false;
+  if (typeof wState?.finished !== 'boolean') return null;
+  return !!(
+    wState.finished ||
+    (strict === false && wState.ended === true && wState.length === 0)
+  );
+}
+
+function isReadableFinished(stream, strict) {
+  if (!isReadableNodeStream(stream)) return null;
+  const rState = stream._readableState;
+  if (rState?.errored) return false;
+  if (typeof rState?.endEmitted !== 'boolean') return null;
+  return !!(
+    rState.endEmitted ||
+    (strict === false && rState.ended === true && rState.length === 0)
+  );
+}
+
+function willEmitClose(stream) {
+  if (!isNodeStream(stream)) return null;
+
+  const wState = stream._writableState;
+  const rState = stream._readableState;
+  const state = wState || rState;
+
+  return (!state && isServerResponse(stream)) || !!(
+    state &&
+    state.autoDestroy &&
+    state.emitClose &&
+    state.closed === false
+  );
+}
+
+function isClosed(stream) {
+  if (!isNodeStream(stream)) {
+    return null;
+  }
+
+  const wState = stream._writableState;
+  const rState = stream._readableState;
+
+  if (
+    typeof wState?.closed === 'boolean' ||
+    typeof rState?.closed === 'boolean'
+  ) {
+    return wState?.closed || rState?.closed;
+  }
+
+  if (typeof stream._closed === 'boolean' && isOutgoingMessage(stream)) {
+    return stream._closed;
+  }
+
+  return null;
+}
+
+function isIterable(obj, isAsync) {
+  if (obj == null) return false;
+  if (isAsync === true) return typeof obj[Symbol.asyncIterator] === 'function';
+  if (isAsync === false) return typeof obj[Symbol.iterator] === 'function';
+  return typeof obj[Symbol.asyncIterator] === 'function' ||
+    typeof obj[Symbol.iterator] === 'function';
+}
+
+module.exports = {
+  createDeferredPromise,
+  isReadableStream,
+  isWritableStream,
+  isDestroyed,
+  destroy,
+  isReadable,
+  isWritable,
+  isWritableNodeStream,
+  isReadableNodeStream,
+  isDuplexNodeStream,
+  isWritableEnded,
+  isReadableEnded,
+  isTransformStream,
+  once,
+  isReadableFinished,
+  isWritableFinished,
+  willEmitClose,
+  isNodeStream,
+  isClosed,
+  isIterable,
+}

--- a/lib/validators.js
+++ b/lib/validators.js
@@ -1,0 +1,38 @@
+function validateBoolean(value, name) {
+  if (typeof value !== 'boolean') {
+    throw new Error('Expected a boolean value for ' + name + ', got ' + value);
+  }
+}
+
+function validateObject(value, name) {
+  if (typeof value !== 'object') {
+    throw new Error('Expected an object for ' + name + ', got ' + value);
+  }
+}
+
+const validateCallback = (callback) => {
+  if (typeof callback !== 'function')
+  throw new Error('Invalid callback, ' + callback);
+};
+
+const validateAbortSignal = (signal, name) => {
+  if (signal !== undefined &&
+      (signal === null ||
+       typeof signal !== 'object' ||
+       !('aborted' in signal))) {
+    throw new Error("Not an abort signal on " + name + ", got " + signal);
+  }
+};
+
+const validateFunction = (value, name) => {
+  if (typeof value !== 'function')
+    console.log(name + " expected a function, got " + value);
+};
+
+module.exports = {
+  validateBoolean,
+  validateObject,
+  validateCallback,
+  validateAbortSignal,
+  validateFunction,
+}

--- a/package.json
+++ b/package.json
@@ -24,7 +24,13 @@
     "url": "https://github.com/balena-io-modules/node-web-streams/issues"
   },
   "dependencies": {
-    "is-stream": "^1.1.0",
+    "is-stream": "^1.1.0"
+  },
+  "peerDependencies": {
+    "stream-browserify": "^3.0.0",
     "web-streams-polyfill": "^1.3.2"
+  },
+  "devDependencies": {
+    "assert": "^2.0.0"
   }
 }

--- a/tests/common.js
+++ b/tests/common.js
@@ -1,0 +1,122 @@
+const util = require('util')
+
+const mustCallChecks = [];
+
+function runCallChecks(exitCode) {
+  if (exitCode !== 0) return;
+
+  const failed = mustCallChecks.filter(function(context) {
+    if ('minimum' in context) {
+      context.messageSegment = `at least ${context.minimum}`;
+      return context.actual < context.minimum;
+    }
+    context.messageSegment = `exactly ${context.exact}`;
+    return context.actual !== context.exact;
+  });
+
+  failed.forEach(function(context) {
+    console.log('Mismatched %s function calls. Expected %s, actual %d.',
+                context.name,
+                context.messageSegment,
+                context.actual);
+    console.log(context.stack.split('\n').slice(2).join('\n'));
+  });
+
+  if (failed.length) process.exit(1);
+}
+
+function mustCall(fn, exact) {
+  return _mustCallInner(fn, exact, 'exact');
+}
+
+function mustSucceed(fn, exact) {
+  return mustCall(function(err, ...args) {
+    assert.ifError(err);
+    if (typeof fn === 'function')
+      return fn.apply(this, args);
+  }, exact);
+}
+
+function mustCallAtLeast(fn, minimum) {
+  return _mustCallInner(fn, minimum, 'minimum');
+}
+
+function _mustCallInner(fn, criteria = 1, field) {
+  if (process._exiting)
+    throw new Error('Cannot use common.mustCall*() in process exit handler');
+  if (typeof fn === 'number') {
+    criteria = fn;
+    fn = noop;
+  } else if (fn === undefined) {
+    fn = noop;
+  }
+
+  if (typeof criteria !== 'number')
+    throw new TypeError(`Invalid ${field} value: ${criteria}`);
+
+  const context = {
+    [field]: criteria,
+    actual: 0,
+    stack: util.inspect(new Error()),
+    name: fn.name || '<anonymous>'
+  };
+
+  // Add the exit listener only once to avoid listener leak warnings
+  if (mustCallChecks.length === 0) process.on('exit', runCallChecks);
+
+  mustCallChecks.push(context);
+
+  const _return = function() { // eslint-disable-line func-style
+    context.actual++;
+    return fn.apply(this, arguments);
+  };
+  // Function instances have own properties that may be relevant.
+  // Let's replicate those properties to the returned function.
+  // Refs: https://tc39.es/ecma262/#sec-function-instances
+  Object.defineProperties(_return, {
+    name: {
+      value: fn.name,
+      writable: false,
+      enumerable: false,
+      configurable: true,
+    },
+    length: {
+      value: fn.length,
+      writable: false,
+      enumerable: false,
+      configurable: true,
+    },
+  });
+  return _return;
+}
+
+function getCallSite(top) {
+  const originalStackFormatter = Error.prepareStackTrace;
+  Error.prepareStackTrace = (err, stack) =>
+    `${stack[0].getFileName()}:${stack[0].getLineNumber()}`;
+  const err = new Error();
+  Error.captureStackTrace(err, top);
+  // With the V8 Error API, the stack is not formatted until it is accessed
+  err.stack; // eslint-disable-line no-unused-expressions
+  Error.prepareStackTrace = originalStackFormatter;
+  return err.stack;
+}
+
+function mustNotCall(msg) {
+  const callSite = getCallSite(mustNotCall);
+  return function mustNotCall(...args) {
+    const argsInfo = args.length > 0 ?
+      `\ncalled with arguments: ${args.map(util.inspect).join(', ')}` : '';
+    assert.fail(
+      `${msg || 'function should not have been called'} at ${callSite}` +
+      argsInfo);
+  };
+}
+
+
+function noop() {}
+
+module.exports = {
+  mustCall,
+  mustNotCall,
+}

--- a/tests/pipeline.js
+++ b/tests/pipeline.js
@@ -1,0 +1,33 @@
+const { pipeline } = require("../lib/pipeline");
+const { PassThrough } = require('stream');
+const { ReadableStream } = require("../lib/isomorphic-streams/node");
+
+class MySource {
+  constructor(value = new Uint8Array(10)) {
+    this.value = value;
+  }
+
+  start(c) {
+    this.started = true;
+    this.controller = c;
+  }
+
+  pull(controller) {
+    controller.enqueue(this.value);
+    controller.close();
+  }
+
+  cancel(reason) {
+    this.canceled = true;
+    this.cancelReason = reason;
+  }
+}
+
+const rs = new ReadableStream({
+  MySource
+})
+const pt = new PassThrough
+
+pipeline(rs, pt, (err) => {
+  console.log(err)
+})

--- a/tests/toDuplex.js
+++ b/tests/toDuplex.js
@@ -1,0 +1,122 @@
+const common = require('./common');
+
+const assert = require('assert');
+
+const {
+  TransformStream,
+} = require('stream/web');
+
+const { newStreamDuplexFromReadableWritablePair } = require('../lib/conversions');
+
+const {
+  finished,
+  pipeline,
+  Readable,
+  Writable,
+} = require('stream');
+
+{
+  const transform = new TransformStream();
+  const duplex = newStreamDuplexFromReadableWritablePair(transform);
+
+  assert(transform.readable.locked);
+  assert(transform.writable.locked);
+
+  duplex.destroy();
+
+}
+
+{
+  const error = new Error('boom');
+  const transform = new TransformStream();
+  const duplex = newStreamDuplexFromReadableWritablePair(transform);
+
+  assert(transform.readable.locked);
+  assert(transform.writable.locked);
+
+  duplex.destroy(error);
+  duplex.on('error', common.mustCall((reason) => {
+    assert.strictEqual(reason, error);
+  }));
+}
+
+{
+  const transform = new TransformStream();
+  const duplex = new newStreamDuplexFromReadableWritablePair(transform);
+
+  duplex.end();
+  duplex.resume();
+
+}
+
+{
+  const ec = new TextEncoder();
+  const dc = new TextDecoder();
+  const transform = new TransformStream({
+    transform(chunk, controller) {
+      const text = dc.decode(chunk);
+      controller.enqueue(ec.encode(text.toUpperCase()));
+    }
+  });
+  const duplex = new newStreamDuplexFromReadableWritablePair(transform, {
+    encoding: 'utf8',
+  });
+
+  duplex.end('hello');
+  duplex.on('data', common.mustCall((chunk) => {
+    assert.strictEqual(chunk, 'HELLO');
+  }));
+  duplex.on('end', common.mustCall());
+
+}
+
+{
+  const ec = new TextEncoder();
+  const dc = new TextDecoder();
+  const transform = new TransformStream({
+    transform: common.mustCall((chunk, controller) => {
+      const text = dc.decode(chunk);
+      controller.enqueue(ec.encode(text.toUpperCase()));
+    })
+  });
+  const duplex = new newStreamDuplexFromReadableWritablePair(transform, {
+    encoding: 'utf8',
+  });
+
+  finished(duplex, common.mustCall());
+
+  duplex.end('hello');
+  duplex.resume();
+}
+
+{
+  const ec = new TextEncoder();
+  const dc = new TextDecoder();
+  const transform = new TransformStream({
+    transform: common.mustCall((chunk, controller) => {
+      const text = dc.decode(chunk);
+      controller.enqueue(ec.encode(text.toUpperCase()));
+    })
+  });
+  const duplex = new newStreamDuplexFromReadableWritablePair(transform, {
+    encoding: 'utf8',
+  });
+
+  const readable = new Readable({
+    read() {
+      readable.push(Buffer.from('hello'));
+      readable.push(null);
+    }
+  });
+
+  const writable = new Writable({
+    write: common.mustCall((chunk, encoding, callback) => {
+      assert.strictEqual(dc.decode(chunk), 'HELLO');
+      assert.strictEqual(encoding, 'buffer');
+      callback();
+    })
+  });
+
+  finished(duplex, common.mustCall());
+  pipeline(readable, duplex, writable, common.mustCall());
+}

--- a/tests/toReadableStream.js
+++ b/tests/toReadableStream.js
@@ -1,0 +1,196 @@
+const common = require('./common');
+
+const assert = require('assert');
+
+const {
+  newReadableStreamFromStreamReadable,
+} = require('../lib/conversions');
+
+const {
+  Duplex,
+  Readable,
+} = require('stream');
+const { PassThrough } = require('stream-browserify');
+
+const readable = new Readable({
+  read() {
+    readable.push('hello');
+    readable.push('null')
+  }
+})
+
+{
+  // Canceling the readableStream closes the readable.
+  const readable = new Readable({
+    read() {
+      readable.push('hello');
+      readable.push(null);
+    }
+  });
+
+  readable.on('close', common.mustCall());
+  readable.on('end', common.mustNotCall());
+  readable.on('pause', common.mustCall());
+  readable.on('resume', common.mustNotCall());
+  readable.on('error', common.mustCall((error) => {
+    assert.strictEqual(error.code, 'ABORT_ERR');
+  }));
+
+  const readableStream = newReadableStreamFromStreamReadable(readable);
+
+  readableStream.cancel().then(common.mustCall());
+}
+
+{
+  // Prematurely destroying the stream.Readable without an error
+  // closes the ReadableStream with a premature close error but does
+  // not error the readable.
+
+  const readable = new Readable({
+    read() {
+      readable.push('hello');
+      readable.push(null);
+    }
+  });
+
+  const readableStream = newReadableStreamFromStreamReadable(readable);
+
+  assert(!readableStream.locked);
+
+  const reader = readableStream.getReader();
+
+  assert.rejects(reader.closed, {
+    code: 'ABORT_ERR',
+  });
+
+  readable.on('end', common.mustNotCall());
+  readable.on('error', common.mustNotCall());
+
+
+  readable.destroy();
+}
+
+{
+  // Ending the readable without an error just closes the
+  // readableStream without an error.
+  const readable = new Readable({
+    read() {
+      readable.push('hello');
+      readable.push(null);
+    }
+  });
+
+  const readableStream = newReadableStreamFromStreamReadable(readable);
+
+  assert(!readableStream.locked);
+
+  const reader = readableStream.getReader();
+
+  reader.closed.then(common.mustCall());
+
+  readable.on('end', common.mustCall());
+  readable.on('error', common.mustNotCall());
+
+
+  readable.push(null);
+}
+
+{
+  // Destroying the readable with an error should error the readableStream
+  const error = new Error('boom');
+  const readable = new Readable({
+    read() {
+      readable.push('hello');
+      readable.push(null);
+    }
+  });
+
+  const readableStream = newReadableStreamFromStreamReadable(readable);
+
+  assert(!readableStream.locked);
+
+  const reader = readableStream.getReader();
+
+  assert.rejects(reader.closed, error);
+
+  readable.on('end', common.mustNotCall());
+  readable.on('error', common.mustCall((reason) => {
+    assert.strictEqual(reason, error);
+  }));
+
+
+  readable.destroy(error);
+}
+
+{
+  const readable = new Readable({
+    encoding: 'utf8',
+    read() {
+      readable.push('hello');
+      readable.push(null);
+    }
+  });
+
+  const readableStream = newReadableStreamFromStreamReadable(readable);
+  const reader = readableStream.getReader();
+
+  readable.on('data', common.mustCall());
+  readable.on('end', common.mustCall());
+  readable.on('close', common.mustCall());
+
+  (async () => {
+    assert.deepStrictEqual(
+      await reader.read(),
+      { value: 'hello', done: false });
+    assert.deepStrictEqual(
+      await reader.read(),
+      { value: undefined, done: true });
+
+  })().then(common.mustCall());
+}
+
+{
+  const data = {};
+  const readable = new Readable({
+    objectMode: true,
+    read() {
+      readable.push(data);
+      readable.push(null);
+    }
+  });
+
+  assert(readable.readableObjectMode);
+
+  const readableStream = newReadableStreamFromStreamReadable(readable);
+  const reader = readableStream.getReader();
+
+  readable.on('data', common.mustCall());
+  readable.on('end', common.mustCall());
+  readable.on('close', common.mustCall());
+
+  (async () => {
+    assert.deepStrictEqual(
+      await reader.read(),
+      { value: data, done: false });
+    assert.deepStrictEqual(
+      await reader.read(),
+      { value: undefined, done: true });
+
+  })().then(common.mustCall());
+}
+
+{
+  const readable = new Readable();
+  readable.destroy();
+  const readableStream = newReadableStreamFromStreamReadable(readable);
+  const reader = readableStream.getReader();
+  reader.closed.then(common.mustCall());
+}
+
+{
+  const duplex = new Duplex({ readable: false });
+  duplex.destroy();
+  const readableStream = newReadableStreamFromStreamReadable(duplex);
+  const reader = readableStream.getReader();
+  reader.closed.then(common.mustCall());
+}

--- a/tests/toReadableWritablePair.js
+++ b/tests/toReadableWritablePair.js
@@ -1,0 +1,245 @@
+const common = require('./common');
+
+const assert = require('assert');
+
+const { newReadableWritablePairFromDuplex } = require('../lib/conversions');
+
+const {
+  PassThrough,
+} = require('stream');
+
+{
+  // Destroying the duplex without an error should close
+  // the readable and error the writable.
+
+  const duplex = new PassThrough();
+  const {
+    readable,
+    writable,
+  } = newReadableWritablePairFromDuplex(duplex);
+
+  const reader = readable.getReader();
+  const writer = writable.getWriter();
+
+  assert.rejects(reader.closed, {
+    code: 'ABORT_ERR',
+  });
+
+  assert.rejects(writer.closed, {
+    code: 'ABORT_ERR',
+  });
+
+  duplex.destroy();
+
+  duplex.on('close', common.mustCall());
+}
+
+{
+  // Destroying the duplex with an error should error
+  // both the readable and writable
+
+  const error = new Error('boom');
+  const duplex = new PassThrough();
+  const {
+    readable,
+    writable,
+  } = newReadableWritablePairFromDuplex(duplex);
+
+  duplex.on('close', common.mustCall());
+  duplex.on('error', common.mustCall((reason) => {
+    assert.strictEqual(reason, error);
+  }));
+
+  const reader = readable.getReader();
+  const writer = writable.getWriter();
+
+  assert.rejects(reader.closed, error);
+  assert.rejects(writer.closed, error);
+
+  duplex.destroy(error);
+}
+
+{
+  const error = new Error('boom');
+  const duplex = new PassThrough();
+  const {
+    readable,
+    writable,
+  } = newReadableWritablePairFromDuplex(duplex);
+
+  duplex.on('close', common.mustCall());
+  duplex.on('error', common.mustCall((reason) => {
+    assert.strictEqual(reason, error);
+  }));
+
+  const reader = readable.getReader();
+  const writer = writable.getWriter();
+
+  reader.closed.then(common.mustCall());
+  assert.rejects(writer.closed, error);
+
+  reader.cancel(error).then(common.mustCall());
+}
+
+{
+  const duplex = new PassThrough();
+  const {
+    readable,
+    writable,
+  } = newReadableWritablePairFromDuplex(duplex);
+
+  duplex.on('close', common.mustCall());
+  duplex.on('error', common.mustNotCall());
+
+  const reader = readable.getReader();
+  const writer = writable.getWriter();
+
+  reader.closed.then(common.mustCall());
+  writer.closed.then(common.mustCall());
+
+  writer.close().then(common.mustCall());
+}
+
+{
+  const error = new Error('boom');
+  const duplex = new PassThrough();
+  const {
+    readable,
+    writable,
+  } = newReadableWritablePairFromDuplex(duplex);
+
+  duplex.on('close', common.mustCall());
+  duplex.on('error', common.mustCall((reason) => {
+    assert.strictEqual(reason, error);
+  }));
+
+  const reader = readable.getReader();
+  const writer = writable.getWriter();
+
+  assert.rejects(reader.closed, error);
+  assert.rejects(writer.closed, error);
+
+  writer.abort(error).then(common.mustCall());
+}
+
+{
+  const duplex = new PassThrough();
+  const {
+    readable,
+    writable,
+  } = newReadableWritablePairFromDuplex(duplex);
+
+  duplex.on('close', common.mustCall());
+
+  duplex.on('error', common.mustCall((error) => {
+    assert.strictEqual(error.code, 'ABORT_ERR');
+  }));
+
+  const reader = readable.getReader();
+  const writer = writable.getWriter();
+
+  assert.rejects(writer.closed, {
+    code: 'ABORT_ERR',
+  });
+
+  reader.cancel();
+}
+
+{
+  const duplex = new PassThrough();
+  const {
+    readable,
+    writable,
+  } = newReadableWritablePairFromDuplex(duplex);
+
+  duplex.on('close', common.mustCall());
+  duplex.on('error', common.mustNotCall());
+
+  const reader = readable.getReader();
+  const writer = writable.getWriter();
+
+  reader.closed.then(common.mustCall());
+  assert.rejects(writer.closed, {
+    code: 'ABORT_ERR',
+  });
+
+  duplex.end();
+}
+
+{
+  const duplex = new PassThrough();
+  const {
+    readable,
+    writable,
+  } = newReadableWritablePairFromDuplex(duplex);
+
+  duplex.on('data', common.mustCall(2));
+  duplex.on('close', common.mustCall());
+  duplex.on('end', common.mustCall());
+  duplex.on('finish', common.mustCall());
+
+  const writer = writable.getWriter();
+  const reader = readable.getReader();
+
+  const ec = new TextEncoder();
+  const dc = new TextDecoder();
+
+  Promise.all([
+    writer.write(ec.encode('hello')),
+    reader.read().then(common.mustCall(({ done, value }) => {
+      assert(!done);
+      assert.strictEqual(dc.decode(value), 'hello');
+    })),
+    reader.read().then(common.mustCall(({ done, value }) => {
+      assert(!done);
+      assert.strictEqual(dc.decode(value), 'there');
+    })),
+    writer.write(ec.encode('there')),
+    writer.close(),
+    reader.read().then(common.mustCall(({ done, value }) => {
+      assert(done);
+      assert.strictEqual(value, undefined);
+    })),
+  ]).then(common.mustCall());
+}
+
+{
+  const duplex = new PassThrough();
+  duplex.destroy();
+  const {
+    readable,
+    writable,
+  } = newReadableWritablePairFromDuplex(duplex);
+  const reader = readable.getReader();
+  const writer = writable.getWriter();
+  reader.closed.then(common.mustCall());
+  writer.closed.then(common.mustCall());
+}
+
+{
+  const duplex = new PassThrough({ writable: false });
+  assert(duplex.readable);
+  assert(!duplex.writable);
+  const {
+    readable,
+    writable,
+  } = newReadableWritablePairFromDuplex(duplex);
+  const reader = readable.getReader();
+  const writer = writable.getWriter();
+  writer.closed.then(common.mustCall());
+  reader.cancel().then(common.mustCall());
+}
+
+{
+  const duplex = new PassThrough({ readable: false });
+  assert(!duplex.readable);
+  assert(duplex.writable);
+  const {
+    readable,
+    writable,
+  } = newReadableWritablePairFromDuplex(duplex);
+  const reader = readable.getReader();
+  const writer = writable.getWriter();
+  reader.closed.then(common.mustCall());
+  writer.close().then(common.mustCall());
+}

--- a/tests/toStreamReadable.js
+++ b/tests/toStreamReadable.js
@@ -1,0 +1,229 @@
+// Flags: --expose-internals --no-warnings
+'use strict';
+
+const common = require('./common');
+
+const assert = require('assert');
+
+const {
+  pipeline,
+  finished,
+  Writable,
+} = require('stream');
+
+const {
+  ReadableStream,
+  WritableStream,
+} = require('stream/web');
+
+const {
+  newStreamReadableFromReadableStream,
+} = require('../lib/conversions');
+
+const {
+  kState,
+} = require('internal/webstreams/util');
+
+class MySource {
+  constructor(value = new Uint8Array(10)) {
+    this.value = value;
+  }
+
+  start(c) {
+    this.started = true;
+    this.controller = c;
+  }
+
+  pull(controller) {
+    controller.enqueue(this.value);
+    controller.close();
+  }
+
+  cancel(reason) {
+    this.canceled = true;
+    this.cancelReason = reason;
+  }
+}
+
+{
+  // Destroying the readable without an error closes
+  // the readableStream.
+
+  const readableStream = new ReadableStream();
+  const readable = newStreamReadableFromReadableStream(readableStream);
+
+  assert(readableStream.locked);
+
+  assert.rejects(readableStream.cancel(), {
+    code: 'ERR_INVALID_STATE',
+  });
+  assert.rejects(readableStream.pipeTo(new WritableStream()), {
+    code: 'ERR_INVALID_STATE',
+  });
+  assert.throws(() => readableStream.tee(), {
+    code: 'ERR_INVALID_STATE',
+  });
+  assert.throws(() => readableStream.getReader(), {
+    code: 'ERR_INVALID_STATE',
+  });
+  assert.throws(() => {
+    readableStream.pipeThrough({
+      readable: new ReadableStream(),
+      writable: new WritableStream(),
+    });
+  }, {
+    code: 'ERR_INVALID_STATE',
+  });
+
+  readable.destroy();
+
+  readable.on('close', common.mustCall(() => {
+    assert.strictEqual(readableStream[kState].state, 'closed');
+  }));
+}
+
+{
+  // Destroying the readable with an error closes the readableStream
+  // without error but records the cancel reason in the source.
+  const error = new Error('boom');
+  const source = new MySource();
+  const readableStream = new ReadableStream(source);
+  const readable = newStreamReadableFromReadableStream(readableStream);
+
+  assert(readableStream.locked);
+
+  readable.destroy(error);
+
+  readable.on('error', common.mustCall((reason) => {
+    assert.strictEqual(reason, error);
+  }));
+
+  readable.on('close', common.mustCall(() => {
+    assert.strictEqual(readableStream[kState].state, 'closed');
+    assert.strictEqual(source.cancelReason, error);
+  }));
+}
+
+{
+  // An error in the source causes the readable to error.
+  const error = new Error('boom');
+  const source = new MySource();
+  const readableStream = new ReadableStream(source);
+  const readable = newStreamReadableFromReadableStream(readableStream);
+
+  assert(readableStream.locked);
+
+  source.controller.error(error);
+
+  readable.on('error', common.mustCall((reason) => {
+    assert.strictEqual(reason, error);
+  }));
+
+  readable.on('close', common.mustCall(() => {
+    assert.strictEqual(readableStream[kState].state, 'errored');
+  }));
+}
+
+{
+  const readableStream = new ReadableStream(new MySource());
+  const readable = newStreamReadableFromReadableStream(readableStream);
+
+  readable.on('data', common.mustCall((chunk) => {
+    assert.deepStrictEqual(chunk, Buffer.alloc(10));
+  }));
+  readable.on('end', common.mustCall());
+  readable.on('close', common.mustCall());
+  readable.on('error', common.mustNotCall());
+}
+
+{
+  const readableStream = new ReadableStream(new MySource('hello'));
+  const readable = newStreamReadableFromReadableStream(readableStream, {
+    encoding: 'utf8',
+  });
+
+  readable.on('data', common.mustCall((chunk) => {
+    assert.deepStrictEqual(chunk, 'hello');
+  }));
+  readable.on('end', common.mustCall());
+  readable.on('close', common.mustCall());
+  readable.on('error', common.mustNotCall());
+}
+
+{
+  const readableStream = new ReadableStream(new MySource());
+  const readable = newStreamReadableFromReadableStream(readableStream, {
+    objectMode: true
+  });
+
+  readable.on('data', common.mustCall((chunk) => {
+    assert.deepStrictEqual(chunk, new Uint8Array(10));
+  }));
+  readable.on('end', common.mustCall());
+  readable.on('close', common.mustCall());
+  readable.on('error', common.mustNotCall());
+}
+
+{
+  const ec = new TextEncoder();
+  const readable = new ReadableStream({
+    start(controller) {
+      controller.enqueue(ec.encode('hello'));
+      setImmediate(() => {
+        controller.enqueue(ec.encode('there'));
+        controller.close();
+      });
+    }
+  });
+  const streamReadable = newStreamReadableFromReadableStream(readable);
+
+  finished(streamReadable, common.mustCall());
+
+  streamReadable.resume();
+}
+
+{
+  const ec = new TextEncoder();
+  const readable = new ReadableStream({
+    start(controller) {
+      controller.enqueue(ec.encode('hello'));
+      setImmediate(() => {
+        controller.enqueue(ec.encode('there'));
+        controller.close();
+      });
+    }
+  });
+  const streamReadable = newStreamReadableFromReadableStream(readable);
+
+  finished(streamReadable, common.mustCall());
+
+  streamReadable.resume();
+}
+
+{
+  const ec = new TextEncoder();
+  const dc = new TextDecoder();
+  const check = ['hello', 'there'];
+  const readable = new ReadableStream({
+    start(controller) {
+      controller.enqueue(ec.encode('hello'));
+      setImmediate(() => {
+        controller.enqueue(ec.encode('there'));
+        controller.close();
+      });
+    }
+  });
+  const writable = new Writable({
+    write: common.mustCall((chunk, encoding, callback) => {
+      assert.strictEqual(dc.decode(chunk), check.shift());
+      assert.strictEqual(encoding, 'buffer');
+      callback();
+    }, 2),
+  });
+
+  const streamReadable = newStreamReadableFromReadableStream(readable);
+
+  pipeline(streamReadable, writable, common.mustCall());
+
+  streamReadable.resume();
+}

--- a/tests/toStreamWritable.js
+++ b/tests/toStreamWritable.js
@@ -1,0 +1,231 @@
+// Flags: --no-warnings --expose-internals
+'use strict';
+
+const common = require('./common');
+
+const assert = require('assert');
+
+const {
+  WritableStream,
+} = require('stream/web');
+
+const {
+  newStreamWritableFromWritableStream,
+} = require('../lib/conversions');
+
+const {
+  finished,
+  pipeline,
+  Readable,
+} = require('stream');
+
+const {
+  kState,
+} = require('internal/webstreams/util');
+
+class TestSource {
+  constructor() {
+    this.chunks = [];
+  }
+
+  start(c) {
+    this.controller = c;
+    this.started = true;
+  }
+
+  write(chunk) {
+    this.chunks.push(chunk);
+  }
+
+  close() {
+    this.closed = true;
+  }
+
+  abort(reason) {
+    this.abortReason = reason;
+  }
+}
+
+[1, {}, false, []].forEach((arg) => {
+  assert.throws(() => newStreamWritableFromWritableStream(arg), {
+    code: 'ERR_INVALID_ARG_TYPE',
+  });
+});
+
+{
+  // Ending the stream.Writable should close the writableStream
+  const source = new TestSource();
+  const writableStream = new WritableStream(source);
+  const writable = newStreamWritableFromWritableStream(writableStream);
+
+  assert(writableStream.locked);
+
+  writable.end('chunk');
+
+  writable.on('close', common.mustCall(() => {
+    assert(writableStream.locked);
+    assert.strictEqual(writableStream[kState].state, 'closed');
+    assert.strictEqual(source.chunks.length, 1);
+    assert.deepStrictEqual(source.chunks[0], Buffer.from('chunk'));
+  }));
+}
+
+{
+  // Destroying the stream.Writable without an error should close
+  // the writableStream with no error.
+  const source = new TestSource();
+  const writableStream = new WritableStream(source);
+  const writable = newStreamWritableFromWritableStream(writableStream);
+
+  assert(writableStream.locked);
+
+  writable.destroy();
+
+  writable.on('close', common.mustCall(() => {
+    assert(writableStream.locked);
+    assert.strictEqual(writableStream[kState].state, 'closed');
+    assert.strictEqual(source.chunks.length, 0);
+  }));
+}
+
+{
+  // Destroying the stream.Writable with an error should error
+  // the writableStream
+  const error = new Error('boom');
+  const source = new TestSource();
+  const writableStream = new WritableStream(source);
+  const writable = newStreamWritableFromWritableStream(writableStream);
+
+  assert(writableStream.locked);
+
+  writable.destroy(error);
+
+  writable.on('error', common.mustCall((reason) => {
+    assert.strictEqual(reason, error);
+  }));
+
+  writable.on('close', common.mustCall(() => {
+    assert(writableStream.locked);
+    assert.strictEqual(writableStream[kState].state, 'errored');
+    assert.strictEqual(writableStream[kState].storedError, error);
+    assert.strictEqual(source.chunks.length, 0);
+  }));
+}
+
+{
+  // Attempting to close, abort, or getWriter on writableStream
+  // should fail because it is locked. An internal error in
+  // writableStream should error the writable.
+  const error = new Error('boom');
+  const source = new TestSource();
+  const writableStream = new WritableStream(source);
+  const writable = newStreamWritableFromWritableStream(writableStream);
+
+  assert(writableStream.locked);
+
+  assert.rejects(writableStream.close(), {
+    code: 'ERR_INVALID_STATE',
+  });
+
+  assert.rejects(writableStream.abort(), {
+    code: 'ERR_INVALID_STATE',
+  });
+
+  assert.throws(() => writableStream.getWriter(), {
+    code: 'ERR_INVALID_STATE',
+  });
+
+  writable.on('error', common.mustCall((reason) => {
+    assert.strictEqual(error, reason);
+  }));
+
+  source.controller.error(error);
+}
+
+{
+  const source = new TestSource();
+  const writableStream = new WritableStream(source);
+  const writable = newStreamWritableFromWritableStream(writableStream);
+
+  writable.on('error', common.mustNotCall());
+  writable.on('finish', common.mustCall());
+  writable.on('close', common.mustCall(() => {
+    assert.strictEqual(source.chunks.length, 1);
+    assert.deepStrictEqual(source.chunks[0], Buffer.from('hello'));
+  }));
+
+  writable.write('hello', common.mustCall());
+  writable.end();
+}
+
+{
+  const source = new TestSource();
+  const writableStream = new WritableStream(source);
+  const writable =
+    newStreamWritableFromWritableStream(writableStream, {
+      decodeStrings: false,
+    });
+
+  writable.on('error', common.mustNotCall());
+  writable.on('finish', common.mustCall());
+  writable.on('close', common.mustCall(() => {
+    assert.strictEqual(source.chunks.length, 1);
+    assert.deepStrictEqual(source.chunks[0], 'hello');
+  }));
+
+  writable.write('hello', common.mustCall());
+  writable.end();
+}
+
+{
+  const source = new TestSource();
+  const writableStream = new WritableStream(source);
+  const writable =
+    newStreamWritableFromWritableStream(
+      writableStream, {
+        objectMode: true
+      });
+  assert(writable.writableObjectMode);
+
+  writable.on('error', common.mustNotCall());
+  writable.on('finish', common.mustCall());
+  writable.on('close', common.mustCall(() => {
+    assert.strictEqual(source.chunks.length, 1);
+    assert.strictEqual(source.chunks[0], 'hello');
+  }));
+
+  writable.write('hello', common.mustCall());
+  writable.end();
+}
+
+{
+  const writableStream = new WritableStream({
+    write: common.mustCall(2),
+    close: common.mustCall(),
+  });
+  const writable = newStreamWritableFromWritableStream(writableStream);
+
+  finished(writable, common.mustCall());
+
+  writable.write('hello');
+  writable.write('world');
+  writable.end();
+}
+
+{
+  const writableStream = new WritableStream({
+    write: common.mustCall(2),
+    close: common.mustCall(),
+  });
+  const writable = newStreamWritableFromWritableStream(writableStream);
+
+  const readable = new Readable({
+    read() {
+      readable.push(Buffer.from('hello'));
+      readable.push(Buffer.from('world'));
+      readable.push(null);
+    }
+  });
+
+  pipeline(readable, writable, common.mustCall());
+}

--- a/tests/toWritableStream.js
+++ b/tests/toWritableStream.js
@@ -1,0 +1,167 @@
+// Flags: --no-warnings --expose-internals
+
+'use strict';
+
+const common = require('./common');
+
+const assert = require('assert');
+
+const {
+  newWritableStreamFromStreamWritable,
+} = require('../lib/conversions');
+
+const {
+  Duplex,
+  Writable,
+  PassThrough,
+} = require('stream');
+
+class TestWritable extends Writable {
+  constructor(asyncWrite = false) {
+    super();
+    this.chunks = [];
+    this.asyncWrite = asyncWrite;
+  }
+
+  _write(chunk, encoding, callback) {
+    this.chunks.push({ chunk, encoding });
+    if (this.asyncWrite) {
+      setImmediate(() => callback());
+      return;
+    }
+    callback();
+  }
+}
+
+[1, {}, false, []].forEach((arg) => {
+  assert.throws(() => newWritableStreamFromStreamWritable(arg), {
+    code: 'ERR_INVALID_ARG_TYPE',
+  });
+});
+
+{
+  // Closing the WritableStream normally closes the stream.Writable
+  // without errors.
+
+  const writable = new TestWritable();
+  writable.on('error', common.mustNotCall());
+  writable.on('finish', common.mustCall());
+  writable.on('close', common.mustCall());
+
+  const writableStream = newWritableStreamFromStreamWritable(writable);
+
+  writableStream.close().then(common.mustCall(() => {
+    assert(writable.destroyed);
+  }));
+}
+
+{
+  // Aborting the WritableStream errors the stream.Writable
+
+  const error = new Error('boom');
+  const writable = new TestWritable();
+  writable.on('error', common.mustCall((reason) => {
+    assert.strictEqual(reason, error);
+  }));
+  writable.on('finish', common.mustNotCall());
+  writable.on('close', common.mustCall());
+
+  const writableStream = newWritableStreamFromStreamWritable(writable);
+
+  writableStream.abort(error).then(common.mustCall(() => {
+    assert(writable.destroyed);
+  }));
+}
+
+{
+  // Destroying the stream.Writable prematurely errors the
+  // WritableStream
+
+  const error = new Error('boom');
+  const writable = new TestWritable();
+
+  const writableStream = newWritableStreamFromStreamWritable(writable);
+  assert.rejects(writableStream.close(), error);
+  writable.destroy(error);
+}
+
+{
+  // Ending the stream.Writable directly errors the WritableStream
+  const writable = new TestWritable();
+
+  const writableStream = newWritableStreamFromStreamWritable(writable);
+
+  assert.rejects(writableStream.close(), {
+    code: 'ABORT_ERR'
+  });
+
+  writable.end();
+}
+
+{
+  const writable = new TestWritable();
+  const writableStream = newWritableStreamFromStreamWritable(writable);
+  const writer = writableStream.getWriter();
+  const ec = new TextEncoder();
+  writer.write(ec.encode('hello')).then(common.mustCall(() => {
+    assert.strictEqual(writable.chunks.length, 1);
+    assert.deepStrictEqual(
+      writable.chunks[0],
+      {
+        chunk: Buffer.from('hello'),
+        encoding: 'buffer'
+      });
+  }));
+}
+
+{
+  const writable = new TestWritable(true);
+
+  writable.on('error', common.mustNotCall());
+  writable.on('close', common.mustCall());
+  writable.on('finish', common.mustCall());
+
+  const writableStream = newWritableStreamFromStreamWritable(writable);
+  const writer = writableStream.getWriter();
+  const ec = new TextEncoder();
+  writer.write(ec.encode('hello')).then(common.mustCall(() => {
+    assert.strictEqual(writable.chunks.length, 1);
+    assert.deepStrictEqual(
+      writable.chunks[0],
+      {
+        chunk: Buffer.from('hello'),
+        encoding: 'buffer'
+      });
+    writer.close().then(common.mustCall());
+  }));
+}
+
+{
+  const duplex = new PassThrough();
+  duplex.setEncoding('utf8');
+  const writableStream = newWritableStreamFromStreamWritable(duplex);
+  const ec = new TextEncoder();
+  writableStream
+    .getWriter()
+    .write(ec.encode('hello'))
+    .then(common.mustCall());
+
+  duplex.on('data', common.mustCall((chunk) => {
+    assert.strictEqual(chunk, 'hello');
+  }));
+}
+
+{
+  const writable = new Writable();
+  writable.destroy();
+  const writableStream = newWritableStreamFromStreamWritable(writable);
+  const writer = writableStream.getWriter();
+  writer.closed.then(common.mustCall());
+}
+
+{
+  const duplex = new Duplex({ writable: false });
+  const writableStream = newWritableStreamFromStreamWritable(duplex);
+  const writer = writableStream.getWriter();
+  writer.closed.then(common.mustCall());
+}


### PR DESCRIPTION
* Allow conversion to and from node and web streams
* uses built-in web streams for node's new api, polyfills if it doesn't exist
* a lot taken from node internal adapters

I'm not sure if I should just go ahead and create a new module, because this introduces breaking changes, but the goal of the repo is still the same.