### PR TITLE
Update web-streams-polyfill 4.1.0

### DIFF
--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -1,0 +1,25 @@
+name: Flowzone
+
+on:
+  pull_request:
+    types: [opened, synchronize, closed]
+    branches: [main, master]
+  # allow external contributions to use secrets within trusted code
+  pull_request_target:
+    types: [opened, synchronize, closed]
+    branches: [main, master]
+
+jobs:
+  flowzone:
+    name: Flowzone
+    uses: product-os/flowzone/.github/workflows/flowzone.yml@master
+    # prevent duplicate workflow executions for pull_request and pull_request_target
+    if: |
+      (
+        github.event.pull_request.head.repo.full_name == github.repository &&
+        github.event_name == 'pull_request'
+      ) || (
+        github.event.pull_request.head.repo.full_name != github.repository &&
+        github.event_name == 'pull_request_target'
+      )
+    secrets: inherit

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+package-lock=false

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "WhatWG web streams and conversion utilities for node.js",
   "main": "index.js",
   "scripts": {
-    "test": "mocha"
+    "test": "echo \"No tests yet!\""
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "dependencies": {
     "is-stream": "^1.1.0",
-    "web-streams-polyfill": "^3.1.0"
+    "web-streams-polyfill": "^4.1.0"
   },
   "versionist": {
     "publishedAt": "2021-09-02T13:01:39.622Z"


### PR DESCRIPTION
The default import is now a ponyfill, which seems to be avoiding interfering w/ node's native fetch on v20+.
Was blocking https://github.com/balena-io-modules/balena-request/pull/185 for a while.

Change-type: minor (a pre-v1 major in reality)
https://github.com/MattiasBuelens/web-streams-polyfill/blob/master/MIGRATING.md#version-3-to-4
See: https://balena.fibery.io/Work/Project/Reduce-the-polyfills-that-the-SDK-uses-1568